### PR TITLE
User Story AB#647091:Enable PREFast warnings as errors. [Error Type: C26429: Use not null] -Minecraft.Shared.Splits-Submodule entt

### DIFF
--- a/src/entt/core/any.hpp
+++ b/src/entt/core/any.hpp
@@ -64,7 +64,7 @@ class basic_any {
             if constexpr(in_situ<Type>) {
                 if(from.mode == policy::owner) {
                     ENTT_ASSERT(to && instance, "Unexpected nullptr");
-                    return new(&static_cast<basic_any *>(const_cast<void *>(to))->storage) Type{ std::move(*const_cast<Type *>(instance))};
+                    return new(&static_cast<basic_any *>(const_cast<void *>(to))->storage) Type{std::move(*const_cast<Type *>(instance))};
                 }
             }
 

--- a/src/entt/core/any.hpp
+++ b/src/entt/core/any.hpp
@@ -56,42 +56,51 @@ class basic_any {
         switch(op) {
         case operation::copy:
             if constexpr(std::is_copy_constructible_v<Type>) {
-                static_cast<basic_any *>(const_cast<void *>(to))->initialize<Type>(*instance);
+                ENTT_ASSERT(to && instance, "Unexpected nullptr");
+                static_cast<basic_any*>(const_cast<void*>(to))->initialize<Type>(*instance);
             }
             break;
         case operation::move:
             if constexpr(in_situ<Type>) {
                 if(from.mode == policy::owner) {
-                    return new(&static_cast<basic_any *>(const_cast<void *>(to))->storage) Type{std::move(*const_cast<Type *>(instance))};
+                    ENTT_ASSERT(to && instance, "Unexpected nullptr");
+                    return new(&static_cast<basic_any*>(const_cast<void*>(to))->storage) Type{ std::move(*const_cast<Type*>(instance)) };
                 }
             }
 
             return (static_cast<basic_any *>(const_cast<void *>(to))->instance = std::exchange(const_cast<basic_any &>(from).instance, nullptr));
         case operation::transfer:
-            if constexpr(std::is_move_assignable_v<Type>) {
-                *const_cast<Type *>(instance) = std::move(*static_cast<Type *>(const_cast<void *>(to)));
+            if constexpr (std::is_move_assignable_v<Type>) {
+                ENTT_ASSERT(to, "Unexpected nullptr");
+                *const_cast<Type*>(instance) = std::move(*static_cast<Type*>(const_cast<void*>(to)));
                 return to;
             }
             [[fallthrough]];
         case operation::assign:
-            if constexpr(std::is_copy_assignable_v<Type>) {
-                *const_cast<Type *>(instance) = *static_cast<const Type *>(to);
+            if constexpr (std::is_copy_assignable_v<Type>) {
+                ENTT_ASSERT(to, "Unexpected nullptr");
+                *const_cast<Type*>(instance) = *static_cast<const Type*>(to);
                 return to;
             }
             break;
         case operation::destroy:
-            if constexpr(in_situ<Type>) {
+            if constexpr (in_situ<Type>) {
+                ENTT_ASSERT(instance, "Unexpected nullptr");
                 instance->~Type();
-            } else if constexpr(std::is_array_v<Type>) {
+            }
+            else if constexpr (std::is_array_v<Type>) {
                 delete[] instance;
-            } else {
+            }
+            else {
                 delete instance;
             }
             break;
         case operation::compare:
-            if constexpr(!std::is_function_v<Type> && !std::is_array_v<Type> && is_equality_comparable_v<Type>) {
-                return *static_cast<const Type *>(instance) == *static_cast<const Type *>(to) ? to : nullptr;
-            } else {
+            ENTT_ASSERT(to && instance, "Unexpected nullptr");
+            if constexpr (!std::is_function_v<Type> && !std::is_array_v<Type> && is_equality_comparable_v<Type>) {
+                return *static_cast<const Type*>(instance) == *static_cast<const Type*>(to) ? to : nullptr;
+            }
+            else {
                 return (instance == to) ? to : nullptr;
             }
         case operation::get:
@@ -450,6 +459,7 @@ Type any_cast(basic_any<Len, Align> &&data) ENTT_NOEXCEPT {
 /*! @copydoc any_cast */
 template<typename Type, std::size_t Len, std::size_t Align>
 const Type *any_cast(const basic_any<Len, Align> *data) ENTT_NOEXCEPT {
+    ENTT_ASSERT(data, "Unexpected nullptr");
     const auto &info = type_id<std::remove_const_t<std::remove_reference_t<Type>>>();
     return static_cast<const Type *>(data->data(info));
 }
@@ -457,6 +467,7 @@ const Type *any_cast(const basic_any<Len, Align> *data) ENTT_NOEXCEPT {
 /*! @copydoc any_cast */
 template<typename Type, std::size_t Len, std::size_t Align>
 Type *any_cast(basic_any<Len, Align> *data) ENTT_NOEXCEPT {
+    ENTT_ASSERT(data, "Unexpected nullptr");
     const auto &info = type_id<std::remove_const_t<std::remove_reference_t<Type>>>();
     // last attempt to make wrappers for const references return their values
     return static_cast<Type *>(static_cast<constness_as_t<basic_any<Len, Align>, Type> *>(data)->data(info));

--- a/src/entt/core/any.hpp
+++ b/src/entt/core/any.hpp
@@ -57,50 +57,47 @@ class basic_any {
         case operation::copy:
             if constexpr(std::is_copy_constructible_v<Type>) {
                 ENTT_ASSERT(to && instance, "Unexpected nullptr");
-                static_cast<basic_any*>(const_cast<void*>(to))->initialize<Type>(*instance);
+                static_cast<basic_any *>(const_cast<void *>(to))->initialize<Type>(*instance);
             }
             break;
         case operation::move:
             if constexpr(in_situ<Type>) {
                 if(from.mode == policy::owner) {
                     ENTT_ASSERT(to && instance, "Unexpected nullptr");
-                    return new(&static_cast<basic_any*>(const_cast<void*>(to))->storage) Type{ std::move(*const_cast<Type*>(instance)) };
+                    return new(&static_cast<basic_any *>(const_cast<void *>(to))->storage) Type{ std::move(*const_cast<Type *>(instance))};
                 }
             }
 
             return (static_cast<basic_any *>(const_cast<void *>(to))->instance = std::exchange(const_cast<basic_any &>(from).instance, nullptr));
         case operation::transfer:
-            if constexpr (std::is_move_assignable_v<Type>) {
+            if constexpr(std::is_move_assignable_v<Type>) {
                 ENTT_ASSERT(to, "Unexpected nullptr");
-                *const_cast<Type*>(instance) = std::move(*static_cast<Type*>(const_cast<void*>(to)));
+                *const_cast<Type *>(instance) = std::move(*static_cast<Type *>(const_cast<void *>(to)));
                 return to;
             }
             [[fallthrough]];
         case operation::assign:
-            if constexpr (std::is_copy_assignable_v<Type>) {
+            if constexpr(std::is_copy_assignable_v<Type>) {
                 ENTT_ASSERT(to, "Unexpected nullptr");
-                *const_cast<Type*>(instance) = *static_cast<const Type*>(to);
+                *const_cast<Type *>(instance) = *static_cast<const Type *>(to);
                 return to;
             }
             break;
         case operation::destroy:
-            if constexpr (in_situ<Type>) {
+            if constexpr(in_situ<Type>) {
                 ENTT_ASSERT(instance, "Unexpected nullptr");
                 instance->~Type();
-            }
-            else if constexpr (std::is_array_v<Type>) {
+            } else if constexpr(std::is_array_v<Type>) {
                 delete[] instance;
-            }
-            else {
+            } else {
                 delete instance;
             }
             break;
         case operation::compare:
             ENTT_ASSERT(to && instance, "Unexpected nullptr");
-            if constexpr (!std::is_function_v<Type> && !std::is_array_v<Type> && is_equality_comparable_v<Type>) {
-                return *static_cast<const Type*>(instance) == *static_cast<const Type*>(to) ? to : nullptr;
-            }
-            else {
+            if constexpr(!std::is_function_v<Type> && !std::is_array_v<Type> && is_equality_comparable_v<Type>) {
+                return *static_cast<const Type *>(instance) == *static_cast<const Type *>(to) ? to : nullptr;
+            } else {
                 return (instance == to) ? to : nullptr;
             }
         case operation::get:

--- a/src/entt/entity/registry.hpp
+++ b/src/entt/entity/registry.hpp
@@ -871,6 +871,7 @@ public:
     [[nodiscard]] decltype(auto) get_or_emplace(const entity_type entity, Args &&...args) {
         ENTT_ASSERT(valid(entity), "Invalid entity");
         auto *cpool = assure<Component>();
+        ENTT_ASSERT(cpool, "Unexpected nullptr");
         return cpool->contains(entity) ? cpool->get(entity) : cpool->emplace(*this, entity, std::forward<Args>(args)...);
     }
 

--- a/src/entt/entity/storage.hpp
+++ b/src/entt/entity/storage.hpp
@@ -644,6 +644,7 @@ public:
     value_type &emplace(const entity_type entt, Args &&...args) {
         const auto pos = base_type::slot();
         auto elem = assure_at_least(pos);
+        ENTT_ASSERT(elem, "Unexpected nullptr");
         construct(elem, std::forward<Args>(args)...);
 
         ENTT_TRY {

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -313,7 +313,7 @@ class basic_view<Entity, get_t<Component...>, exclude_t<Exclude...>> {
     };
 
     [[nodiscard]] const auto *candidate() const ENTT_NOEXCEPT {
-        return (std::min)({static_cast<const basic_common_type *>(std::get<storage_type<Component>*>(pools))... }, [](const auto *lhs, const auto *rhs) {
+        return (std::min)({static_cast<const basic_common_type *>(std::get<storage_type<Component> *>(pools))...}, [](const auto *lhs, const auto *rhs) {
             ENTT_ASSERT(lhs && rhs, "Unexpected nullptr");
             return lhs->size() < rhs->size();
         });

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -313,7 +313,7 @@ class basic_view<Entity, get_t<Component...>, exclude_t<Exclude...>> {
     };
 
     [[nodiscard]] const auto *candidate() const ENTT_NOEXCEPT {
-        return (std::min)({ static_cast<const basic_common_type*>(std::get<storage_type<Component>*>(pools))... }, [](const auto* lhs, const auto* rhs) {
+        return (std::min)({static_cast<const basic_common_type *>(std::get<storage_type<Component>*>(pools))... }, [](const auto *lhs, const auto *rhs) {
             ENTT_ASSERT(lhs && rhs, "Unexpected nullptr");
             return lhs->size() < rhs->size();
         });

--- a/src/entt/entity/view.hpp
+++ b/src/entt/entity/view.hpp
@@ -313,7 +313,8 @@ class basic_view<Entity, get_t<Component...>, exclude_t<Exclude...>> {
     };
 
     [[nodiscard]] const auto *candidate() const ENTT_NOEXCEPT {
-        return (std::min)({static_cast<const basic_common_type *>(std::get<storage_type<Component> *>(pools))...}, [](const auto *lhs, const auto *rhs) {
+        return (std::min)({ static_cast<const basic_common_type*>(std::get<storage_type<Component>*>(pools))... }, [](const auto* lhs, const auto* rhs) {
+            ENTT_ASSERT(lhs && rhs, "Unexpected nullptr");
             return lhs->size() < rhs->size();
         });
     }

--- a/src/entt/meta/factory.hpp
+++ b/src/entt/meta/factory.hpp
@@ -590,6 +590,7 @@ template<typename Type>
  */
 inline void meta_reset(const id_type id) ENTT_NOEXCEPT {
     auto clear_chain = [](auto **curr, auto... member) {
+        ENTT_ASSERT(curr, "Unexpected nullptr");
         for(; *curr; *curr = std::exchange((*curr)->next, nullptr)) {
             if constexpr(sizeof...(member) != 0u) {
                 static_assert(sizeof...(member) == 1u, "Assert in defense of the future me");
@@ -598,7 +599,9 @@ inline void meta_reset(const id_type id) ENTT_NOEXCEPT {
         }
     };
 
-    for(auto **it = internal::meta_context::global(); *it; it = &(*it)->next) {
+    auto** it = internal::meta_context::global();
+    ENTT_ASSERT(it, "Unexpected nullptr");
+    for(; *it; it = &(*it)->next) {
         if(auto *node = *it; node->id == id) {
             clear_chain(&node->prop);
             clear_chain(&node->base);

--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -969,6 +969,7 @@ private:
 class meta_type {
     template<auto Member, typename Pred>
     [[nodiscard]] const auto *lookup(meta_any *const args, const typename internal::meta_type_node::size_type sz, Pred pred) const {
+        ENTT_ASSERT(args, "Unexpected nullptr");
         std::decay_t<decltype(node->*Member)> candidate{};
         size_type extent{sz + 1u};
         bool ambiguous{};
@@ -978,7 +979,6 @@ class meta_type {
                 size_type direct{};
                 size_type ext{};
 
-                ENTT_ASSERT(args, "Unexpected nullptr");
                 for(size_type next{}; next < sz && next == (direct + ext) && args[next]; ++next) {
                     const auto type = args[next].type();
                     const auto other = curr->arg(next);

--- a/src/entt/meta/meta.hpp
+++ b/src/entt/meta/meta.hpp
@@ -159,6 +159,7 @@ class meta_any {
         static_assert(std::is_same_v<std::remove_reference_t<std::remove_const_t<Type>>, Type>, "Invalid type");
 
         if constexpr(!std::is_void_v<Type>) {
+            ENTT_ASSERT(to, "Unexpected nullptr");
             switch(op) {
             case operation::deref:
                 if constexpr(is_meta_pointer_like_v<Type>) {
@@ -977,6 +978,7 @@ class meta_type {
                 size_type direct{};
                 size_type ext{};
 
+                ENTT_ASSERT(args, "Unexpected nullptr");
                 for(size_type next{}; next < sz && next == (direct + ext) && args[next]; ++next) {
                     const auto type = args[next].type();
                     const auto other = curr->arg(next);
@@ -1469,6 +1471,7 @@ class meta_sequence_container::meta_iterator {
             ++any_cast<It &>(const_cast<any &>(from));
             break;
         case operation::deref:
+            ENTT_ASSERT(to, "Unexpected nullptr");
             static_cast<meta_any *>(to)->emplace<typename std::iterator_traits<It>::reference>(*any_cast<const It &>(from));
             break;
         }

--- a/src/entt/meta/node.hpp
+++ b/src/entt/meta/node.hpp
@@ -137,10 +137,12 @@ class ENTT_API meta_node {
     [[nodiscard]] static auto *meta_conversion_helper() ENTT_NOEXCEPT {
         if constexpr(std::is_arithmetic_v<Type>) {
             return +[](void *bin, const void *value) {
+                ENTT_ASSERT(value, "Unexpected nullptr");
                 return bin ? static_cast<double>(*static_cast<Type *>(bin) = static_cast<Type>(*static_cast<const double *>(value))) : static_cast<double>(*static_cast<const Type *>(value));
             };
         } else if constexpr(std::is_enum_v<Type>) {
             return +[](void *bin, const void *value) {
+                ENTT_ASSERT(value, "Unexpected nullptr");
                 return bin ? static_cast<double>(*static_cast<Type *>(bin) = static_cast<Type>(static_cast<std::underlying_type_t<Type>>(*static_cast<const double *>(value)))) : static_cast<double>(*static_cast<const Type *>(value));
             };
         } else {
@@ -198,6 +200,7 @@ template<typename... Args>
 
 template<auto Member, typename Type>
 [[nodiscard]] static std::decay_t<decltype(std::declval<internal::meta_type_node>().*Member)> find_by(const Type &info_or_id, const internal::meta_type_node *node) {
+    ENTT_ASSERT(node, "Unexpected nullptr");
     for(auto *curr = node->*Member; curr; curr = curr->next) {
         if constexpr(std::is_same_v<Type, type_info>) {
             if(*curr->type->info == info_or_id) {


### PR DESCRIPTION
### [ADO](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**ado**)
- https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/647091

<!-- *** EDIT_NUMBER_INTO_LINK_ABOVE_REPLACING_### ***
    - Include a link to each work item on ADO for the user story, bugfix, etc.
    - If there is not an ADO work item for the PR, then consider making one.
-->



### [Description / PR Commit Message](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**description-%2F-pr-commit-message**)

<!-- *** COMMENT_DESCRIPTION_PR_COMMIT_MESSAGE ***
    - Add a description of the PR and why it is being made.
    - May contain root cause, perf impact, background info, system design, changes made, creator impact, etc.
    - Upon merging, copy the text you typed below here and use that as the PR Commit Message.
-->

Check with PREFast, found 15 errors:

```
1. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\meta.hpp(970): warning C26429: Symbol 'args' is never tested for nullness, it can be marked as not_null (f.23).
2. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\factory.hpp(599): warning C26429: Symbol 'curr' is never tested for nullness, it can be marked as not_null (f.23).
3. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\factory.hpp(601): warning C26429: Symbol 'it' is never tested for nullness, it can be marked as not_null (f.23).
4. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\node.hpp(200): warning C26429: Symbol 'node' is never tested for nullness, it can be marked as not_null (f.23).
5. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\core\any.hpp(459): warning C26429: Symbol 'data' is never tested for nullness, it can be marked as not_null (f.23).
6. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\node.hpp(141): warning C26429: Symbol 'value' is never tested for nullness, it can be marked as not_null (f.23).
7. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\core\any.hpp(452): warning C26429: Symbol 'data' is never tested for nullness, it can be marked as not_null (f.23).
8. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\core\any.hpp(48): warning C26429: Symbol 'instance' is never tested for nullness, it can be marked as not_null (f.23).
9. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\core\any.hpp(46): warning C26429: Symbol 'to' is never tested for nullness, it can be marked as not_null (f.23).
10. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\entity\storage.hpp(646): warning C26429: Symbol 'elem' is never tested for nullness, it can be marked as not_null (f.23).
11. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\meta.hpp(158): warning C26429: Symbol 'to' is never tested for nullness, it can be marked as not_null (f.23).
12. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\meta.hpp(1466): warning C26429: Symbol 'to' is never tested for nullness, it can be marked as not_null (f.23).
13. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\entity\registry.hpp(873): warning C26429: Symbol 'cpool' is never tested for nullness, it can be marked as not_null (f.23).
14. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\meta\node.hpp(145): warning C26429: Symbol 'value' is never tested for nullness, it can be marked as not_null (f.23).
15. C:\Minecraftpe\handheld\src-external\entt_\entt\src\entt\entity\view.hpp(315): warning C26429: Symbol 'lhs' is never tested for nullness, it can be marked as not_null (f.23).

```


**The modifications are as following:**
Use `ENTT_ASSERT` to test for nullness.




### [Guidance for Review](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**guidance-for-review**)

<!-- *** COMMENT__GUIDANCE_FOR_REVIEW ***
    - Provide additional information to ease review of this PR; this section does not survive into git history.
    - May contain: what you dev tested, perf captures, screenshots, requested feedback, recommended order to review files in, auto test reliability results, changelog exemption reason, test review exemption reason, etc.
-->
Synchronize with main on 2021-11-11.


### [Author's Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**author%27s-checklist**)
- [ ] Completed Automated Test Review or have Exemption ([automated test policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/4447)).
- [ ] Have Changelogs for Public Changes or have Exemption ([changelogs policy](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/3921/Pull-Request-Changelogs)).
- [x] Set the Manual Quality Validation Required field and applicable Validation Notes in ADO item(s).
- [x] Builds and Test Runs passed.
- [x] Reliability runs of affected tests passed (Unit 1 time, Server 10 time, Functional 50 times).



### [Reviewers' Checklist](https://dev-mc.visualstudio.com/Minecraft/_wiki/wikis/Minecraft.wiki/7893/Pull-Request-Template-for-Bedrock-minecraftpe?anchor=**reviewers%27-checklist**)
- [ ] Correct target branch.
- [ ] Reason/root cause understood; documented in Description / PR Commit message.
- [ ] Architecturally fits accepted patterns.
- [ ] Introduced no known bugs and is secure.
- [ ] No hard-coded "secrets".
- [ ] Follows Coding Standards ([contributing.md](https://github.com/Mojang/Minecraftpe/blob/main/CONTRIBUTING.md)).
- [ ] Content creator impact is understood and acceptable.
